### PR TITLE
Fix agent routes conflicts and enhance dashboard UX

### DIFF
--- a/app/agent/page.tsx
+++ b/app/agent/page.tsx
@@ -64,6 +64,7 @@ export default function AgentDashboard() {
   const [searchTerm, setSearchTerm] = useState("")
   const [statusFilter, setStatusFilter] = useState("all")
   const [showCommunicationHub, setShowCommunicationHub] = useState(false)
+  const [debouncedSearch, setDebouncedSearch] = useState("")
 
   const router = useRouter()
   const pathname = usePathname()
@@ -89,11 +90,8 @@ export default function AgentDashboard() {
   }, [searchTerm, statusFilter, router, pathname, searchParams])
 
   // Debounce search term
-  const debouncedSearch = useMemo(() => searchTerm, [searchTerm])
   useEffect(() => {
-    const t = setTimeout(() => {
-      // no-op, debounced via URL sync above
-    }, 250)
+    const t = setTimeout(() => setDebouncedSearch(searchTerm), 300)
     return () => clearTimeout(t)
   }, [searchTerm])
 

--- a/app/agent/page.tsx
+++ b/app/agent/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { useAgentAuth } from "@/hooks/use-agent-auth"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -30,6 +30,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useRealTimeCases } from "@/hooks/use-real-time-cases"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
 
 interface AgentCase {
   id: string
@@ -63,6 +64,38 @@ export default function AgentDashboard() {
   const [searchTerm, setSearchTerm] = useState("")
   const [statusFilter, setStatusFilter] = useState("all")
   const [showCommunicationHub, setShowCommunicationHub] = useState(false)
+
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  // Initialize filters from URL
+  useEffect(() => {
+    const q = searchParams?.get("q") || ""
+    const status = searchParams?.get("status") || "all"
+    setSearchTerm(q)
+    setStatusFilter(status)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Persist filters to URL
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams?.toString())
+    if (searchTerm) params.set("q", searchTerm)
+    else params.delete("q")
+    if (statusFilter && statusFilter !== "all") params.set("status", statusFilter)
+    else params.delete("status")
+    router.replace(`${pathname}?${params.toString()}`)
+  }, [searchTerm, statusFilter, router, pathname, searchParams])
+
+  // Debounce search term
+  const debouncedSearch = useMemo(() => searchTerm, [searchTerm])
+  useEffect(() => {
+    const t = setTimeout(() => {
+      // no-op, debounced via URL sync above
+    }, 250)
+    return () => clearTimeout(t)
+  }, [searchTerm])
 
   useEffect(() => {
     if (agent) {
@@ -105,9 +138,10 @@ export default function AgentDashboard() {
   }
 
   const filteredCases = cases.filter((case_) => {
+    const q = debouncedSearch.toLowerCase()
     const matchesSearch =
-      case_.victim_email.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      case_.case_id.toLowerCase().includes(searchTerm.toLowerCase())
+      case_.victim_email.toLowerCase().includes(q) ||
+      case_.case_id.toLowerCase().includes(q)
     const matchesStatus = statusFilter === "all" || case_.status === statusFilter
     return matchesSearch && matchesStatus
   })
@@ -317,6 +351,14 @@ export default function AgentDashboard() {
                         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                           {/* Cases List */}
                           <div className="space-y-4">
+                            {filteredCases.length === 0 && (
+                              <Card className="border-dashed">
+                                <CardContent className="p-8 text-center text-muted-foreground">
+                                  <p className="font-medium mb-1">No cases found</p>
+                                  <p className="text-sm">Try adjusting your search or filters.</p>
+                                </CardContent>
+                              </Card>
+                            )}
                             {filteredCases.map((case_) => (
                               <Card
                                 key={case_.id}
@@ -369,7 +411,7 @@ export default function AgentDashboard() {
                           </div>
 
                           {/* Case Details */}
-                          {selectedCase && (
+                          {selectedCase && filteredCases.length > 0 && (
                             <Card>
                               <CardHeader>
                                 <div className="flex items-center justify-between">
@@ -440,6 +482,14 @@ export default function AgentDashboard() {
                   </TabsContent>
 
                   <TabsContent value="communications" className="mt-6">
+                    {filteredCases.length === 0 ? (
+                      <Card className="border-dashed">
+                        <CardContent className="p-12 text-center text-muted-foreground">
+                          <p className="font-medium mb-1">No conversations to show</p>
+                          <p className="text-sm">Select an active case to start communicating.</p>
+                        </CardContent>
+                      </Card>
+                    ) : null}
                     <Card>
                       <CardHeader>
                         <CardTitle>Communication Hub</CardTitle>

--- a/app/agent/page.tsx
+++ b/app/agent/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useMemo } from "react"
+import { useState, useEffect } from "react"
 import { useAgentAuth } from "@/hooks/use-agent-auth"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"

--- a/app/api/agent/auth/route.ts
+++ b/app/api/agent/auth/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server"
+import { NextResponse } from "next/server"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { rateLimiter } from "@/lib/security/rate-limiter"
 import type { Agent, AgentPublic } from "@/types/entities"
@@ -57,10 +58,11 @@ export async function POST(request: Request) {
 
     const token = await signSession({ sub: agentData.id, role: "agent" })
     const res = NextResponse.json({ success: true, agent: agentData as AgentPublic })
+    const isProd = process.env.NODE_ENV === "production"
     res.cookies.set("agent_session", token, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
+      secure: isProd,
+      sameSite: isProd ? "none" : "lax",
       path: "/",
       maxAge: 60 * 60 * 24 * 7,
     })

--- a/app/api/agent/auth/route.ts
+++ b/app/api/agent/auth/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server"
-import { NextResponse } from "next/server"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { rateLimiter } from "@/lib/security/rate-limiter"
 import type { Agent, AgentPublic } from "@/types/entities"

--- a/app/api/agent/auth/route.ts
+++ b/app/api/agent/auth/route.ts
@@ -58,11 +58,10 @@ export async function POST(request: Request) {
 
     const token = await signSession({ sub: agentData.id, role: "agent" })
     const res = NextResponse.json({ success: true, agent: agentData as AgentPublic })
-    const isProd = process.env.NODE_ENV === "production"
     res.cookies.set("agent_session", token, {
       httpOnly: true,
-      secure: isProd,
-      sameSite: isProd ? "none" : "lax",
+      secure: true,
+      sameSite: "none",
       path: "/",
       maxAge: 60 * 60 * 24 * 7,
     })

--- a/app/api/agent/logout/route.ts
+++ b/app/api/agent/logout/route.ts
@@ -4,7 +4,6 @@ import { NextResponse } from "next/server"
 
 export async function POST() {
   const res = NextResponse.json({ success: true })
-  const isProd = process.env.NODE_ENV === "production"
-  res.cookies.set("agent_session", "", { httpOnly: true, secure: isProd, sameSite: isProd ? "none" : "lax", path: "/", maxAge: 0 })
+  res.cookies.set("agent_session", "", { httpOnly: true, secure: true, sameSite: "none", path: "/", maxAge: 0 })
   return res
 }

--- a/app/api/agent/logout/route.ts
+++ b/app/api/agent/logout/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server"
 
+import { NextResponse } from "next/server"
+
 export async function POST() {
   const res = NextResponse.json({ success: true })
-  res.cookies.set("agent_session", "", { httpOnly: true, secure: process.env.NODE_ENV === "production", sameSite: "lax", path: "/", maxAge: 0 })
+  const isProd = process.env.NODE_ENV === "production"
+  res.cookies.set("agent_session", "", { httpOnly: true, secure: isProd, sameSite: isProd ? "none" : "lax", path: "/", maxAge: 0 })
   return res
 }

--- a/app/api/agent/me/route.ts
+++ b/app/api/agent/me/route.ts
@@ -1,5 +1,4 @@
 import { createAdminClient } from "@/lib/supabase/admin"
-import { createAdminClient } from "@/lib/supabase/admin"
 import { verifySession } from "@/lib/security/session"
 
 export async function GET(request: Request) {

--- a/app/api/agent/me/route.ts
+++ b/app/api/agent/me/route.ts
@@ -1,5 +1,3 @@
-import { NextResponse } from "next/server"
-import { NextResponse } from "next/server"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { verifySession } from "@/lib/security/session"
 

--- a/app/api/agent/me/route.ts
+++ b/app/api/agent/me/route.ts
@@ -1,4 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/admin"
+import { createAdminClient } from "@/lib/supabase/admin"
 import { verifySession } from "@/lib/security/session"
 
 export async function GET(request: Request) {
@@ -9,19 +10,19 @@ export async function GET(request: Request) {
     const payload = token ? await verifySession(token) : null
 
     if (!payload || !payload.sub || payload.role !== "agent") {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401, headers: { "content-type": "application/json" } })
     }
 
     const supabase = createAdminClient()
     const { data: agent, error } = await supabase.from("agents").select("*").eq("id", payload.sub).single()
 
     if (error || !agent) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401, headers: { "content-type": "application/json" } })
     }
 
     const { password_hash, ...agentPublic } = agent as any
-    return NextResponse.json({ agent: agentPublic })
+    return new Response(JSON.stringify({ agent: agentPublic }), { status: 200, headers: { "content-type": "application/json" } })
   } catch (e) {
-    return NextResponse.json({ error: "Server error" }, { status: 500 })
+    return new Response(JSON.stringify({ error: "Server error" }), { status: 500, headers: { "content-type": "application/json" } })
   }
 }

--- a/app/api/agent/me/route.ts
+++ b/app/api/agent/me/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server"
+import { NextResponse } from "next/server"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { verifySession } from "@/lib/security/session"
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { AuthProviderWrapper } from "@/components/auth/auth-provider"
 import { Suspense } from "react"
 import "./globals.css"
 import { RouteTransitionOverlay } from "@/components/ui/route-transition-overlay"
+import { Toaster } from "sonner"
 
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || "https://fortivault.example.com"),
@@ -75,6 +76,7 @@ export default function RootLayout({
           <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
             <AuthProviderWrapper>{children}</AuthProviderWrapper>
             <RouteTransitionOverlay />
+            <Toaster richColors position="top-center" />
           </ThemeProvider>
         </Suspense>
         <Analytics />

--- a/lib/api/response.ts
+++ b/lib/api/response.ts
@@ -1,47 +1,76 @@
-import { NextResponse } from "next/server"
-
-import { NextResponse } from "next/server"
-
 export function ok(data?: any) {
-  return NextResponse.json(data || { success: true }, { status: 200 })
+  return new Response(JSON.stringify(data || { success: true }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
 }
 
 export function created(data?: any) {
-  return NextResponse.json(data || { success: true }, { status: 201 })
+  return new Response(JSON.stringify(data || { success: true }), {
+    status: 201,
+    headers: { "content-type": "application/json" },
+  })
 }
 
 export function badRequest(message: string = "Bad Request") {
-  return NextResponse.json({ error: message }, { status: 400 })
+  return new Response(JSON.stringify({ error: message }), {
+    status: 400,
+    headers: { "content-type": "application/json" },
+  })
 }
 
 export function unauthorized(message: string = "Unauthorized") {
-  return NextResponse.json({ error: message }, { status: 401 })
+  return new Response(JSON.stringify({ error: message }), {
+    status: 401,
+    headers: { "content-type": "application/json" },
+  })
 }
 
 export function forbidden(message: string = "Forbidden") {
-  return NextResponse.json({ error: message }, { status: 403 })
+  return new Response(JSON.stringify({ error: message }), {
+    status: 403,
+    headers: { "content-type": "application/json" },
+  })
 }
 
 export function notFound(message: string = "Not Found") {
-  return NextResponse.json({ error: message }, { status: 404 })
+  return new Response(JSON.stringify({ error: message }), {
+    status: 404,
+    headers: { "content-type": "application/json" },
+  })
 }
 
 export function methodNotAllowed(message: string = "Method Not Allowed") {
-  return NextResponse.json({ error: message }, { status: 405 })
+  return new Response(JSON.stringify({ error: message }), {
+    status: 405,
+    headers: { "content-type": "application/json" },
+  })
 }
 
 export function conflict(message: string = "Conflict") {
-  return NextResponse.json({ error: message }, { status: 409 })
+  return new Response(JSON.stringify({ error: message }), {
+    status: 409,
+    headers: { "content-type": "application/json" },
+  })
 }
 
 export function tooManyRequests(message: string = "Too Many Requests") {
-  return NextResponse.json({ error: message }, { status: 429 })
+  return new Response(JSON.stringify({ error: message }), {
+    status: 429,
+    headers: { "content-type": "application/json" },
+  })
 }
 
 export function serverError(message: string = "Internal Server Error") {
-  return NextResponse.json({ error: message }, { status: 500 })
+  return new Response(JSON.stringify({ error: message }), {
+    status: 500,
+    headers: { "content-type": "application/json" },
+  })
 }
 
 export function notImplemented(message: string = "Not Implemented") {
-  return NextResponse.json({ error: message }, { status: 501 })
+  return new Response(JSON.stringify({ error: message }), {
+    status: 501,
+    headers: { "content-type": "application/json" },
+  })
 }

--- a/lib/api/response.ts
+++ b/lib/api/response.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server"
 
+import { NextResponse } from "next/server"
+
 export function ok(data?: any) {
   return NextResponse.json(data || { success: true }, { status: 200 })
 }


### PR DESCRIPTION
## Purpose

Based on the conversation history, this PR addresses:
- **Route conflicts**: Resolving the duplicate `createAdminClient` import issue in agent routes that was causing module parse failures
- **Dashboard review**: Implementing UX improvements and feature enhancements for the agents dashboard
- **Bug fixes**: Addressing logic debugging issues and general code quality improvements

## Code changes

### Agent Dashboard Enhancements
- **URL persistence**: Added search and filter state persistence to URL parameters using Next.js navigation hooks
- **Debounced search**: Implemented 300ms debounced search to improve performance
- **Empty states**: Added proper empty state cards when no cases are found or no conversations exist
- **Improved filtering**: Enhanced case filtering logic with debounced search terms

### API Route Fixes
- **Import conflicts**: Removed duplicate `NextResponse` import in `/api/agent/me/route.ts`
- **Response standardization**: Replaced `NextResponse.json()` with native `Response` constructor for consistency
- **Cookie security**: Updated session cookies to use `secure: true` and `sameSite: "none"` for better cross-origin support

### Global Improvements
- **Toast notifications**: Added Sonner toast provider to the root layout
- **Response utilities**: Refactored API response helpers to use native Response constructor instead of NextResponse

These changes resolve the module conflicts, improve the agent dashboard user experience, and standardize API response handling across the application.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 39`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fff83a6f5e174a029fe16af60d4b2c63/vibe-sanctuary)

👀 [Preview Link](https://fff83a6f5e174a029fe16af60d4b2c63-vibe-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fff83a6f5e174a029fe16af60d4b2c63</projectId>-->
<!--<branchName>vibe-sanctuary</branchName>-->